### PR TITLE
Fix data truncation in executemany

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
 - Official support for Python 3.7.
-- Add optional `hostname` parameter to `ctds.connect`.
+- Add optional `hostname` parameter to `ctds.connect()`.
 
 ### Fixed
 - Retry on SQL Server unittest database setup failures due to race conditions
@@ -19,6 +19,8 @@ builds (FTP no longer works due to firewall issues.)
 - Fix OS X Travis CI build.
 - Improve SQL Server -> DB API 2.0 error mappings.
 - Remove Python 2.6 from Appveyor CI due to lack of support.
+- Fix `ctds.Cursor.executemany()` truncating data for variable width types.
+https://github.com/zillow/ctds/issues/25.
 
 ## [1.7.0] - 2018-01-24
 ### Added

--- a/src/ctds/include/parameter.h
+++ b/src/ctds/include/parameter.h
@@ -41,14 +41,17 @@ bool Parameter_output(struct Parameter* rpcparam);
     Get the SQL type of this parameter.
 
     @note The caller is required to release the returned value using free().
+
+    @param minimum_width [in] Use the MAX width for variable width types instead of
+      inferring it from the size of the parameter.
 */
-char* Parameter_sqltype(struct Parameter* rpcparam);
+char* Parameter_sqltype(struct Parameter* rpcparam, bool maximum_width);
 
 PyObject* Parameter_value(struct Parameter* rpcparam);
 
 #if !defined(CTDS_USE_SP_EXECUTESQL)
 
-char* Parameter_serialize(struct Parameter* rpcparam, size_t* nserialized);
+char* Parameter_serialize(struct Parameter* rpcparam, bool maximum_width, size_t* nserialized);
 
 #endif /* if !defined(CTDS_USE_SP_EXECUTESQL) */
 

--- a/src/ctds/include/tds.h
+++ b/src/ctds/include/tds.h
@@ -30,6 +30,8 @@ extern PyObject* PyExc_tds_NotSupportedError;
 #define TDS_NCHAR_MIN_SIZE 1
 #define TDS_NCHAR_MAX_SIZE 4000
 
+#define TDS_BINARY_MAX_SIZE 8000
+
 enum ParamStyle {
     ParamStyle_named,
     ParamStyle_numeric


### PR DESCRIPTION
Data truncation can occur when multiple parameter sequences are passed to `executemany` and the first sequence contains values that map to variable length SQL types. The width of the SQL type is determined by the values in the first sequence, so if these are shorter than values in subsequent parameter sequences to the values are truncated. This is due to the implementation of `executemany`, which uses `sp_executesql` internally and must declare the type of the parameter before the first execution.