### PR TITLE
Fix bulk_copy exceptions when attempting to copy no rows

### DIFF
--- a/src/ctds/connection.c
+++ b/src/ctds/connection.c
@@ -1659,7 +1659,10 @@ static PyObject* Connection_bulk_insert(PyObject* self, PyObject* args, PyObject
             /* Always call bcp_done() regardless of previous errors. */
             Py_BEGIN_ALLOW_THREADS
 
-                processed = bcp_done(connection->dbproc);
+                if (sent)
+                    processed = bcp_done(connection->dbproc);
+                else
+                    processed = 0;
 
             Py_END_ALLOW_THREADS
 

--- a/tests/test_connection_bulk_insert.py
+++ b/tests/test_connection_bulk_insert.py
@@ -235,6 +235,28 @@ insert.\
             finally:
                 connection.rollback()
 
+    def test_insert_nothing(self):
+        with self.connect(autocommit=False) as connection:
+            try:
+                with connection.cursor() as cursor:
+                    cursor.execute(
+                        '''
+                        CREATE TABLE {0}
+                        (
+                            PrimaryKey INT NOT NULL PRIMARY KEY,
+                        )
+                        '''.format(self.test_insert_tablock.__name__)
+                    )
+
+                inserted = connection.bulk_insert(
+                    self.test_insert_tablock.__name__,
+                    ()
+                )
+                self.assertEqual(inserted, 0)
+
+            finally:
+                connection.rollback()
+
     def test_insert_tablock(self):
         with self.connect(autocommit=False) as connection:
             try:


### PR DESCRIPTION
See #36, seemed a simple enough fix :) 

ctds source explicitly specifies `/* Always call bcp_done() regardless of previous errors. */`, so I may be completely off-track here.